### PR TITLE
Fix issue with not being able to order on author

### DIFF
--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -47,6 +47,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         "state",
         "modified_date",
     ]
+    ordering = ['-versions__modified']
     search_fields = ("title",)
 
     def get_list_display(self, request):

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -40,17 +40,17 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
     change_list_template = "admin/djangocms_pageadmin/pagecontent/change_list.html"
     list_display_links = None
     list_filter = (LanguageFilter, UnpublishedFilter)
+    _list_display = [
+        "get_title",
+        "url",
+        "author",
+        "state",
+        "modified_date",
+    ]
     search_fields = ("title",)
 
     def get_list_display(self, request):
-        return [
-            "get_title",
-            "url",
-            "author",
-            "state",
-            "modified_date",
-            self._list_actions(request),
-        ]
+        return self._list_display + [self._list_actions(request)]
 
     def get_queryset(self, request):
         """Filter PageContent objects by current site of the request.
@@ -123,7 +123,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         return version.created_by
 
     author.short_description = _("author")
-    author.admin_order_field = "versions__author"
+    author.admin_order_field = "versions__created_by"
 
     def is_locked(self, obj):
         version = self.get_version(obj)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -7,7 +7,7 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from cms.api import add_plugin, create_page
+from cms.api import add_plugin
 from cms.models import PageContent, PageUrl
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.utils import get_object_preview_url
@@ -47,6 +47,18 @@ class AdminTestCase(CMSTestCase):
         self.assertRedirects(
             response, "/en/admin/login/?next=/en/admin/cms/pagecontent/"
         )
+
+    def test_ordering_author(self):
+        model = PageContent
+        order = 2
+        author = PageContentAdmin._list_display[order]
+        self.assertEqual(author, 'author', 'Make sure we are checking the correct ordering')
+
+        with self.login_user_context(self.get_superuser()):
+            url = self.get_admin_url(model, "changelist")
+            url = f'{url}?o={order + 1}'
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
 
 
 class FiltersTestCase(CMSTestCase):


### PR DESCRIPTION
This PR fixes the bug of not being able to order by author, right now it throws a 500 error. I've also added a default ordering on modified_date. 