### PR TITLE
Fill in missing requirements in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local.sqlite
 htmlcov/
 .python-version
 docs/_build/
+venv

--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,33 @@ Run::
 Add ``djangocms_pageadmin`` to your project's ``INSTALLED_APPS``.
 It should appear **after** ``cms`` app in order to override the
 default PageContent admin class.
+
+
+Development
+===========
+
+Extending PageAdmin
+-------------------
+
+If you need to extend the pageadmin further you can do that in the following way.
+
+    # admin.py
+    from django.contrib import admin
+    from djangocms_pageadmin.admin import PageContentAdmin
+
+    class CustomPageContentAdmin(PageContentAdmin):
+        # your changes here
+        pass
+
+    admin.site.unregister(PageContent)
+    admin.site.register(PageContent, CustomPageContentAdmin)
+
+
+Running Tests
+-------------
+
+You can run the tests by executing:
+
+    python -m venv venv
+    source venv/bin/activate
+    python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,19 @@ import djangocms_pageadmin
 
 INSTALL_REQUIREMENTS = [
     "Django>=1.11,<2.0",
-    "django-cms>=3.5.0",
+    "django_cms",
     "django-treebeard>=4.3",
+    "djangocms_versioning",
+    "djangocms_version_locking",
 ]
 
+TESTS_REQUIRE = [
+    "djangocms_helper",
+    "djangocms-text-ckeditor",
+    "beautifulsoup4",
+    "factory_boy",
+    "lxml"
+]
 
 setup(
     name="djangocms-pageadmin",
@@ -29,4 +38,10 @@ setup(
     url="https://github.com/FidelityInternational/djangocms-pageadmin",
     license="BSD",
     test_suite="tests.settings.run",
+    tests_require=TESTS_REQUIRE,
+    dependency_links=[
+        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
+        "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
+        "http://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13"
+    ]
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,5 @@ factory_boy
 beautifulsoup4
 lxml
 djangocms-text-ckeditor
+git+git://github.com/divio/djangocms-versioning.git#egg=djangocms-versioning
+git+git://github.com/FidelityInternational/djangocms-version-locking.git#egg=djangocms-version-locking

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,7 +38,6 @@ HELPER_SETTINGS = {
 
 def run():
     from djangocms_helper import runner
-
     runner.cms("djangocms_pageadmin", extra_args=[])
 
 


### PR DESCRIPTION
This PR allows you to use `python setup.py test` to run all the tests without doing any other installations. The caveat here is that `setup.py` in `djangocms-version-locking` and `djangocms-versioning` needs to be modified to use `zip_safe=False` for this to work. So that the egg is a directory instead of a zip file. Otherwise running the tests won't be able to access the migrations.  

While I was testing this out I manually unzipped the eggs to make it work. 