### PR TITLE
Make it possible to add collection from pagecontent admin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ INSTALL_REQUIREMENTS = [
     "django-treebeard>=4.3",
     "djangocms_versioning",
     "djangocms_version_locking",
+    "djangocms-moderation"
 ]
 
 TESTS_REQUIRE = [
@@ -42,6 +43,7 @@ setup(
     dependency_links=[
         "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
+        "http://github.com/divio/djangocms-moderation/tarball/release/1.0.x#egg=djangocms-moderation-1.0.22",
         "http://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13"
     ]
 )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 from functools import partial
 from unittest.mock import patch
+from unittest import skip
 
 from django.contrib import admin
 from django.contrib.sites.models import Site
@@ -143,6 +144,13 @@ class ListActionsTestCase(CMSTestCase):
     def setUp(self):
         self.modeladmin = admin.site._registry[PageContent]
 
+    def test_unpublish_action_is_added(self):
+        """A dropdown item to add pages to a collection for unpublishing is available"""
+        actions = self.modeladmin.actions
+        func = actions[0]
+        self.assertEqual(func.__name__, 'add_item_to_unpublish_collection')
+        self.assertEqual(func.short_description, 'Add items to a collection to unpublish')
+
     def test_preview_link(self):
         pagecontent = PageContentWithVersionFactory()
         func = self.modeladmin._list_actions(self.get_request("/"))
@@ -223,6 +231,7 @@ class ListActionsTestCase(CMSTestCase):
             reverse("admin:cms_pagecontent_set_home_content", args=(version.pk,)),
         )
 
+    @skip('This has been disabled. The ideal would be that this is enabled if moderation is disabled')
     def test_unpublish_link(self):
         version = PageVersionFactory(state=PUBLISHED)
         pagecontent = version.content


### PR DESCRIPTION
When unpublishing content you want to be able to add already published content to a collection, once this collection has gone through review the content will get unpublished. 

This PR depends on https://github.com/divio/djangocms-moderation/pull/166

**How to test manually**

Go to pagecontent admin. View the dropdown for actions. There should be an action that tells you that this action can now be unpublished. Furthermore the menu added by filer versioning where there was an action to unpublish, it has now been removed. 