### PR TITLE
Fix error when placeholder does not exist

### DIFF
--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -186,7 +186,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
     def _get_duplicate_link(self, obj, request, disabled=False):
         url = reverse(
-            "admin:{app}_{model}_duplicate_content".format(
+            "admin:{app}_{model}_duplicate".format(
                 app=self.model._meta.app_label, model=self.model._meta.model_name
             ),
             args=(obj.pk,),
@@ -348,7 +348,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
             form=form,
             object_id=object_id,
             duplicate_url=reverse(
-                "admin:{}_{}_duplicate_content".format(*info), args=(obj.pk,)
+                "admin:{}_{}_duplicate".format(*info), args=(obj.pk,)
             ),
             back_url=reverse("admin:{}_{}_changelist".format(*info)),
         )
@@ -395,18 +395,21 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name
-        return [
+        # we replace the duplicate with our function.
+        old_urls = [v for v in super().get_urls() if 'duplicate' not in str(v.name)]
+        new_urls = [
             url(
                 r"^(.+)/duplicate-content/$",
                 self.admin_site.admin_view(self.duplicate_view),
-                name="{}_{}_duplicate_content".format(*info),
+                name="{}_{}_duplicate".format(*info),
             ),
             url(
                 r"^(.+)/set-home-content/$",
                 self.admin_site.admin_view(self.set_home_view),
                 name="{}_{}_set_home_content".format(*info),
             ),
-        ] + super().get_urls()
+        ]
+        return new_urls + old_urls
 
     class Media:
         css = {"all": ("djangocms_pageadmin/css/actions.css",)}

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -281,6 +281,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         """
         return admin.ModelAdmin.changelist_view(self, request, extra_context)
 
+    @transaction.atomic
     def duplicate_view(self, request, object_id):
         """Duplicate a specified PageContent.
 
@@ -332,7 +333,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
                 placeholders = obj.get_placeholders()
                 for source_placeholder in placeholders:
-                    target_placeholder = new_page_content.placeholders.get(
+                    target_placeholder, created = new_page_content.placeholders.get_or_create(
                         slot=source_placeholder.slot
                     )
                     source_placeholder.copy_plugins(

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -333,6 +333,9 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
                 placeholders = obj.get_placeholders()
                 for source_placeholder in placeholders:
+                    # Keep all placeholders even if they are not in the template anymore to ensure the data is kept,
+                    # keeping only placeholders from rescanning the template would not keep any legacy content
+                    # which could in theory be remapped repaired at a later date
                     target_placeholder, created = new_page_content.placeholders.get_or_create(
                         slot=source_placeholder.slot
                     )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -488,8 +488,11 @@ class DuplicateViewTestCase(CMSTestCase):
         self.assertEqual(form.errors["slug"], ["Slug must not be empty."])
 
     def test_post(self):
+        """the slot for content is always there, the slot for navigation needs
+        to be created"""
         pagecontent = PageContentWithVersionFactory(template="page.html")
         placeholder = PlaceholderFactory(slot="content", source=pagecontent)
+        placeholder = PlaceholderFactory(slot="navigation", source=pagecontent)
         add_plugin(placeholder, "TextPlugin", pagecontent.language, body="Test text")
         with self.login_user_context(self.get_superuser()):
             response = self.client.post(


### PR DESCRIPTION
When duplicating a page I got the error that the placeholder didn't exist. So instead of only getting the placeholder, we get_or_create the placeholder. Then we know that the placeholder will exist for sure. 

We also make the transaction atomic for this view so IF it would fail for whatever reason it would roll back completely so we don't happen to leave any half duplicated pages behind. 

It would be good to have a test for this that verifies the error. 

After this has been merged. I will move the duplicate view into djangocms-versioning. After that change has been merged into djangocms-versioning we can remove the duplicate-view in pageadmin as it will become redundant. 