### PR TITLE
SubMenu as first menu item was causing a crash in change_admin_menu

### DIFF
--- a/djangocms_pageadmin/cms_toolbars.py
+++ b/djangocms_pageadmin/cms_toolbars.py
@@ -20,8 +20,8 @@ class PageAdminToolbar(PageToolbar):
         super().change_admin_menu()
         menu = self.toolbar.get_menu(ADMIN_MENU_IDENTIFIER)
         item = menu.items[0]
+        # Handle menu items like SubMenu that have no url attribute:
         if item and getattr(item, 'url', None) and "admin/cms/pagecontent/" in item.url:
-            # Handle menu items like SubMenu that have no url attribute.
             url = admin_reverse("cms_pagecontent_changelist")  # cms page admin
             item.url = url
 

--- a/djangocms_pageadmin/cms_toolbars.py
+++ b/djangocms_pageadmin/cms_toolbars.py
@@ -20,7 +20,7 @@ class PageAdminToolbar(PageToolbar):
         super().change_admin_menu()
         menu = self.toolbar.get_menu(ADMIN_MENU_IDENTIFIER)
         item = menu.items[0]
-        # Handle menu items like SubMenu that have no url attribute:
+        # Menu items like SubMenu that have no url attribute:
         if item and getattr(item, 'url', None) and "admin/cms/pagecontent/" in item.url:
             url = admin_reverse("cms_pagecontent_changelist")  # cms page admin
             item.url = url

--- a/djangocms_pageadmin/cms_toolbars.py
+++ b/djangocms_pageadmin/cms_toolbars.py
@@ -20,7 +20,8 @@ class PageAdminToolbar(PageToolbar):
         super().change_admin_menu()
         menu = self.toolbar.get_menu(ADMIN_MENU_IDENTIFIER)
         item = menu.items[0]
-        if item and item.url and "admin/cms/pagecontent/" in item.url:
+        if item and getattr(item, 'url', None) and "admin/cms/pagecontent/" in item.url:
+            # Handle menu items like SubMenu that have no url attribute.
             url = admin_reverse("cms_pagecontent_changelist")  # cms page admin
             item.url = url
 


### PR DESCRIPTION
Test to reproduce bug where first menu item is a SubMenu.

change_admin_menu was assuming the first item always has a url field, which is not the case with SubMenu.