### PR TITLE
OPENCMS-1040 Edit link hidden in PageContent list.

### DIFF
--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
@@ -14,8 +13,6 @@ from django.utils.decorators import method_decorator
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import override, ugettext_lazy as _
 from django.views.decorators.http import require_POST
-
-import os
 
 from cms import api
 from cms.admin.pageadmin import PageContentAdmin as DefaultPageContentAdmin

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
@@ -13,6 +14,8 @@ from django.utils.decorators import method_decorator
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import override, ugettext_lazy as _
 from django.views.decorators.http import require_POST
+
+import os
 
 from cms import api
 from cms.admin.pageadmin import PageContentAdmin as DefaultPageContentAdmin
@@ -154,7 +157,10 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         return [
             self._set_home_link,
             self._get_preview_link,
-            self._get_edit_link,
+            # CAVEAT : get_edit_link Commented out to hide edit link from change list
+            # Edit page content can be accessed from preview
+            # Below line should be uncommented  change is added to open the edit link new tab
+            # self._get_edit_link,
             self._get_duplicate_link,
             self._get_unpublish_link,
             self._get_manage_versions_link,

--- a/djangocms_pageadmin/test_utils/factories.py
+++ b/djangocms_pageadmin/test_utils/factories.py
@@ -35,7 +35,7 @@ class UserFactory(factory.django.DjangoModelFactory):
         return manager.create_user(*args, **kwargs)
 
 
-class AbstractVersionFactory(factory.DjangoModelFactory):
+class AbstractVersionFactory(factory.django.DjangoModelFactory):
     object_id = factory.SelfAttribute("content.id")
     content_type = factory.LazyAttribute(
         lambda o: ContentType.objects.get_for_model(o.content)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,6 @@ mock
 factory_boy
 beautifulsoup4
 lxml
-djangocms-text-ckeditor
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
 https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,6 +10,6 @@ lxml
 djangocms-text-ckeditor
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
-https://github.com/divio/djangocms-text-ckeditor/archive/support/4.0.x.zip
+https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 git+git://github.com/divio/djangocms-versioning.git#egg=djangocms-versioning
 git+git://github.com/FidelityInternational/djangocms-version-locking.git#egg=djangocms-version-locking

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,5 +10,6 @@ lxml
 djangocms-text-ckeditor
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
+https://github.com/divio/djangocms-text-ckeditor/archive/support/4.0.x.zip
 git+git://github.com/divio/djangocms-versioning.git#egg=djangocms-versioning
 git+git://github.com/FidelityInternational/djangocms-version-locking.git#egg=djangocms-version-locking

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,5 +8,7 @@ factory_boy
 beautifulsoup4
 lxml
 djangocms-text-ckeditor
+django-classy-tags<2.0.0
+django-sekizai<2.0.0
 git+git://github.com/divio/djangocms-versioning.git#egg=djangocms-versioning
 git+git://github.com/FidelityInternational/djangocms-version-locking.git#egg=djangocms-version-locking

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,4 +1,5 @@
 from functools import partial
+from unittest import skip
 from unittest.mock import patch
 
 import django
@@ -171,6 +172,7 @@ class ListActionsTestCase(CMSTestCase):
         self.assertEqual(element["title"], "Preview")
         self.assertEqual(element["href"], get_object_preview_url(pagecontent))
 
+    @skip("Skip Test as Edit link is commented in list_actions")
     def test_edit_link(self):
         user = UserFactory()
         version = PageVersionFactory(created_by=user)
@@ -191,6 +193,7 @@ class ListActionsTestCase(CMSTestCase):
             ),
         )
 
+    @skip("Skip Test as Edit link is commented in list_actions")
     def test_edit_link_inactive(self):
         pagecontent = PageContentWithVersionFactory()
         func = self.modeladmin._list_actions(self.get_request("/"))


### PR DESCRIPTION
Edit link hidden in PageContent list. Content editors  requires the editlink open in new tab.
Pagecontent can now be edited from preview mode