### PR TITLE
Feat: Target attribute added to preview button

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-
+* feat: Added monkeypatch to inject target="_blank" attribute into the toolbar preview button
 
 1.0.0 (2022-02-10)
 ==================

--- a/djangocms_pageadmin/apps.py
+++ b/djangocms_pageadmin/apps.py
@@ -5,3 +5,6 @@ from django.utils.translation import gettext_lazy as _
 class PageAdminConfig(AppConfig):
     name = "djangocms_pageadmin"
     verbose_name = _("django CMS Pages")
+
+    def ready(self):
+        import djangocms_pageadmin.monkeypatch  # noqa: F401

--- a/djangocms_pageadmin/monkeypatch.py
+++ b/djangocms_pageadmin/monkeypatch.py
@@ -1,0 +1,30 @@
+from django.utils.translation import ugettext_lazy as _
+
+from cms.cms_toolbars import PlaceholderToolbar
+from cms.toolbar.utils import get_object_preview_url
+from cms.toolbar.items import ButtonList
+
+from djangocms_version_locking.monkeypatch.cms_toolbars import ButtonWithAttributes
+
+
+def new_preview_button(func):
+    """
+    The cms core does not allow for custom attributes to be specified for toolbar buttons, therefore,
+    monkeypatch the method which adds preview to use the ButtonWithAttributes item from djangocms-version-locking
+    """
+    def inner(self, **kwargs):
+        url = get_object_preview_url(self.toolbar.obj, language=self.toolbar.request_language)
+        item = ButtonList(side=self.toolbar.RIGHT)
+        preview_button = ButtonWithAttributes(
+            _("Preview"),
+            url=url,
+            disabled=False,
+            extra_classes=["cms-btn", "cms-btn-switch-save"],
+            html_attributes={"target": "_blank"},
+        )
+        item.buttons.append(preview_button)
+        self.toolbar.add_item(item)
+    return inner
+
+
+PlaceholderToolbar.add_preview_button = new_preview_button(PlaceholderToolbar.add_preview_button)

--- a/djangocms_pageadmin/monkeypatch.py
+++ b/djangocms_pageadmin/monkeypatch.py
@@ -5,7 +5,7 @@ from cms.toolbar.items import ButtonList
 from cms.toolbar.utils import get_object_preview_url
 
 from djangocms_version_locking.monkeypatch.cms_toolbars import (
-    ButtonWithAttributes
+    ButtonWithAttributes,
 )
 
 

--- a/djangocms_pageadmin/monkeypatch.py
+++ b/djangocms_pageadmin/monkeypatch.py
@@ -1,10 +1,12 @@
 from django.utils.translation import ugettext_lazy as _
 
 from cms.cms_toolbars import PlaceholderToolbar
-from cms.toolbar.utils import get_object_preview_url
 from cms.toolbar.items import ButtonList
+from cms.toolbar.utils import get_object_preview_url
 
-from djangocms_version_locking.monkeypatch.cms_toolbars import ButtonWithAttributes
+from djangocms_version_locking.monkeypatch.cms_toolbars import (
+    ButtonWithAttributes
+)
 
 
 def new_preview_button(func):

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -9,6 +9,7 @@ mock
 pyflakes>=2.1.1
 
 # Unreleased django-cms 4.0 compatible packages
+https://github.com/django-cms/djangocms-alias/tarball/master#egg=djangocms-alias
 https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms
 https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
 https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,6 +24,7 @@ HELPER_SETTINGS = {
         "djangocms_text_ckeditor",
         "djangocms_versioning",
         "djangocms_version_locking",
+        "djangocms_alias",
     ],
     "LANGUAGES": (
         ("en", "English"),

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -1,0 +1,20 @@
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
+
+from djangocms_pageadmin.test_utils import factories
+
+
+class ToolbarMonkeyPatchTestCase(CMSTestCase):
+    def test_preview_button_contains_target(self):
+        """
+        The monkeypatch adds the target attribute to the preview button only
+        """
+        user = self.get_superuser()
+        version = factories.PageVersionFactory(created_by=user, content__template="page.html")
+        url = get_object_edit_url(version.content)
+
+        with self.login_user_context(user):
+            response = self.client.get(url)
+
+        self.assertContains(response, 'class="cms-btn cms-btn cms-btn-switch-save" target="_blank"')
+        self.assertContains(response, get_object_preview_url(version.content))


### PR DESCRIPTION
In order to modify the preview button within the toolbar, it was necessary to use a monkeypatch, and the existing ButtonWithAttributes (from djangocms_version_locking). 

There should be investigation into altering the button provided by the core, as attributes in buttons are useful, without having to monkeypatch. 

Due to the fact that the button template is reused, it is not possible to override there either.

The changes to djangocms_alias requirements and settings is to fix tests not running.