### PR TITLE
fix: Admin burger menu excluding Preview and Edit buttons in all languages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Admin burger menu excluding Preview and Edit buttons in all languages
 * feat: Migrate CI to use Github Actions
 
 1.1.1 (2022-06-25)

--- a/djangocms_pageadmin/static/djangocms_pageadmin/js/actions.js
+++ b/djangocms_pageadmin/static/djangocms_pageadmin/js/actions.js
@@ -44,8 +44,9 @@
       }
 
       $(actions[0]).children('.cms-page-admin-action-btn').each(function (index, item) {
-        /* exclude some buttons */
-        if (item.title == "Preview" || item.title == "Edit") {
+        /* exclude preview and edit buttons */
+        if (item.classList.contains('cms-page-admin-action-preview') ||
+            item.classList.contains('cms-page-admin-action-edit')) {
           return;
         }
 


### PR DESCRIPTION
The admin burger menu does not work for any other language than English. This is an issue where the Preview and Edit buttons are added to the burger menu and any bound js events are stripped because a new dom element is created.  