### PR TITLE
feat: PageContent search checks PageUrls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 * feat: PageContent search checks PageUrls
+
 1.1.2 (2022-07-20)
 ==================
 * fix: Admin burger menu excluding Preview and Edit buttons in all languages

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-
+* feat: PageContent search checks PageUrls
 1.1.2 (2022-07-20)
 ==================
 * fix: Admin burger menu excluding Preview and Edit buttons in all languages

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -116,8 +116,8 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         This is a workaround to avoid replicating the functionality of get_search_results in Django, which checks
         whether a queryset is distinct based on search_fields. We cannot use the standard search_fields configuration,
         because this would not be language aware, and would results in hits on URLs in languages different to the users.
-        As we are looking across reverse FK relations, we know
-        that this method should always return use_distinct=True, therefore if a search has been made, set it as such.
+        As we are looking across reverse FK relations, we know that this method should always return use_distinct=True,
+        therefore if a search has been made, set it as such.
         https://github.com/django/django/blob/2a62cdcfec85938f40abb2e9e6a9ff497e02afe8/django/contrib/admin/options.py#L980 # NOQA
         """
         if search_term:

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -109,6 +109,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
             page__urls__language=language
         )
         # This is a workaround to avoid bringing in much of the code which decides whether a queryset is distinct.
+        # https://github.com/django/django/blob/2a62cdcfec85938f40abb2e9e6a9ff497e02afe8/django/contrib/admin/options.py#L980 # NOQA
         if not list(queryset) == list(original_queryset):
             use_distinct = True
         return queryset, use_distinct
@@ -118,7 +119,6 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
     def state(self, obj):
         version = self.get_version(obj)
-
         return version.get_state_display()
 
     state.short_description = _("state")

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -113,8 +113,11 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         )
 
         """
-        This is a workaround to avoid replicating the functionality of get_search_results in django, which checks
-        whether a queryset is distinct.
+        This is a workaround to avoid replicating the functionality of get_search_results in Django, which checks
+        whether a queryset is distinct based on search_fields. We cannot use the standard search_fields configuration,
+        because this would not be language aware, and would results in hits on URLs in languages different to the users.
+        As we are looking across reverse FK relations, we know
+        that this method should always return use_distinct=True, therefore if a search has been made, set it as such.
         https://github.com/django/django/blob/2a62cdcfec85938f40abb2e9e6a9ff497e02afe8/django/contrib/admin/options.py#L980 # NOQA
         """
         if search_term:

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -315,7 +315,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         # so we remove it before initiating the standard Django changelist view.
         if 'page_id' in request.GET:
             request.GET = request.GET.copy()
-            del(request.GET['page_id'])
+            del (request.GET['page_id'])
 
         return admin.ModelAdmin.changelist_view(self, request, extra_context)
 

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -103,7 +103,7 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
         language = get_language()
         returned_queryset, use_distinct = super().get_search_results(request, queryset, search_term)
         """
-        While the returned_queryset contains searches for title, without filtering on the original, we are unable to 
+        While the returned_queryset contains searches for title, without filtering on the original, we are unable to
         search for symbols within the URL, such as '-'. Therefore, filter the original queryset and combine.
         Language must also be filtered in order to prevent hits on PageContent which have URLS in multiple languages.
         """

--- a/djangocms_pageadmin/test_utils/factories.py
+++ b/djangocms_pageadmin/test_utils/factories.py
@@ -115,10 +115,10 @@ class PageContentWithVersionFactory(PageContentFactory):
 
 
 class PageUrlFactory(factory.django.DjangoModelFactory):
-    slug = ''
-    path = ''
+    slug = factory.Faker("slug")
+    path = ""
     managed = False
-    language = 'en'
+    language = "en"
 
     class Meta:
         model = PageUrl

--- a/djangocms_pageadmin/test_utils/factories.py
+++ b/djangocms_pageadmin/test_utils/factories.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 
-from cms.models import Page, PageContent, Placeholder, TreeNode
+from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
 import factory
 from djangocms_versioning.models import Version
@@ -112,3 +112,13 @@ class PageContentWithVersionFactory(PageContentFactory):
             # Simple build, do nothing.
             return
         PageVersionFactory(content=self, **kwargs)
+
+
+class PageUrlFactory(factory.django.DjangoModelFactory):
+    slug = ''
+    path = ''
+    managed = False
+    language = 'en'
+
+    class Meta:
+        model = PageUrl

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -653,7 +653,7 @@ class CMSPageToolbarTestCase(CMSTestCase):
 
 class AdminSearchTestCase(CMSTestCase):
     """
-    Test case covers custom search functionality
+    Test case covers custom search functionality.
     """
     def setUp(self):
         template_1 = get_cms_setting('TEMPLATES')[0][0]
@@ -685,12 +685,6 @@ class AdminSearchTestCase(CMSTestCase):
             path=slugify(self.pagecontent.title),
             slug=slugify(self.pagecontent.title),
         )
-        PageUrlFactory(
-            page=self.pagecontent.page,
-            language="de",
-            path=slugify(self.pagecontent.title),
-            slug=slugify(self.pagecontent.title),
-        )
         request = self._get_page_admin_request("test")
         url_instance = self.pagecontent.page.urls.filter(language="en").first()
         url = url_instance.path
@@ -714,11 +708,6 @@ class AdminSearchTestCase(CMSTestCase):
             language=self.language,
             slug=slugify(self.pagecontent.title),
         )
-        PageUrlFactory(
-            page=self.pagecontent.page,
-            language="de",
-            slug=slugify(self.pagecontent.title),
-        )
         request = self._get_page_admin_request("test")
 
         with self.login_user_context(self.get_superuser()):
@@ -733,7 +722,7 @@ class AdminSearchTestCase(CMSTestCase):
 
     def test_page_url_search_partial_match_from_path(self):
         """
-        Partial URL matches to the path return the pagecontent associated with it
+        Partial URL matches to the path return the pagecontent associated with it.
         """
         # Create multiple PageUrl for the same page, with different languages
         page_url = PageUrlFactory(
@@ -776,7 +765,7 @@ class AdminSearchTestCase(CMSTestCase):
 
     def test_page_url_search_url_in_other_language(self):
         """
-        With a match in a different language, but not in the current one, the pagecontent should not be returned
+        With a match in a different language, but not in the current one, the pagecontent should not be returned.
         """
         PageUrlFactory(
             page=self.pagecontent.page,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -787,3 +787,25 @@ class AdminSearchTestCase(CMSTestCase):
         results = soup.find_all("td", "field-url")
 
         self.assertEqual(results, [])
+
+    def test_page_url_search_term_symbol(self):
+        """
+        When searching by symbol, appropriate results should be returned
+        """
+        page_url = PageUrlFactory(
+            page=self.pagecontent.page,
+            language="en",
+            path=slugify("test-path"),
+            slug=slugify("test-path"),
+        )
+        request = self._get_page_admin_request("-")
+        url = page_url.path
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(request, follow=True)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find_all("td", "field-url")
+
+        self.assertEqual(len(results), 1)
+        self.assertIn(url, results[0].text)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -4,11 +4,10 @@ from unittest.mock import patch
 
 from django.contrib import admin
 from django.contrib.sites.models import Site
-from django.test import RequestFactory, TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import override as force_language
 
 from cms.api import add_plugin
 from cms.models import PageContent, PageUrl

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -678,7 +678,6 @@ class AdminSearchTestCase(CMSTestCase):
         """
         Partial URL matches to the slug and path return the PageContent associated with it.
         """
-        # Create multiple PageUrl for the same page, with different languages
         PageUrlFactory(
             page=self.pagecontent.page,
             language=self.language,
@@ -702,7 +701,6 @@ class AdminSearchTestCase(CMSTestCase):
         """
         Partial URL matches to the slug return the pagecontent associated with it.
         """
-        # Create multiple PageUrl for the same page, with different languages
         PageUrlFactory(
             page=self.pagecontent.page,
             language=self.language,
@@ -724,7 +722,6 @@ class AdminSearchTestCase(CMSTestCase):
         """
         Partial URL matches to the path return the pagecontent associated with it.
         """
-        # Create multiple PageUrl for the same page, with different languages
         page_url = PageUrlFactory(
             page=self.pagecontent.page,
             language=self.language,
@@ -767,6 +764,7 @@ class AdminSearchTestCase(CMSTestCase):
         """
         With a match in a different language, but not in the current one, the pagecontent should not be returned.
         """
+        # Create URLs in more than one language
         PageUrlFactory(
             page=self.pagecontent.page,
             language="en",


### PR DESCRIPTION
### Description

Implementation to add page search by url in the PageContentAdmin. Due to the fact a page can have multiple urls in different languages, this implementation factors in language, and only returns those which are appropriate for the used language.

### Related resources

### Checklist

- [x]   I have opened this pull request against master
- [x]   I have added or modified the tests when changing logic
- [x]   I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog