### PR TITLE
fix: Version4 confirmation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 ==========
 * feat: PageContent search checks PageUrls
 * feat: CSV export functionality added to the change list
+* fix: Added CONFIRM_VERSION4 in test_settings to show intend of using v4
 
 1.1.2 (2022-07-20)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Unreleased
 ==========
 * feat: PageContent search checks PageUrls
 * feat: CSV export functionality added to the change list
-* fix: Added CONFIRM_VERSION4 in test_settings to show intend of using v4
+* fix: Added CMS_CONFIRM_VERSION4 in test_settings to show intend of using v4
 
 1.1.2 (2022-07-20)
 ==================

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -61,7 +61,6 @@ HELPER_SETTINGS = {
     "PARLER_ENABLE_CACHING": False,
     "LANGUAGE_CODE": "en",
     # Due to a recent temporary change in develop-4, we now need to confirm that we intend to use v4
-    # https://github.com/django-cms/django-cms/commit/ff6cb9b5dced92eadef62694e989d601e9475b30
     "CMS_CONFIRM_VERSION4": True,
 }
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -60,6 +60,8 @@ HELPER_SETTINGS = {
     ),
     "PARLER_ENABLE_CACHING": False,
     "LANGUAGE_CODE": "en",
+    # Due to a recent temporary change in develop-4, we now need to confirm that we intend to use v4
+    "CONFIRM_VERSION4": True,
 }
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -61,7 +61,7 @@ HELPER_SETTINGS = {
     "PARLER_ENABLE_CACHING": False,
     "LANGUAGE_CODE": "en",
     # Due to a recent temporary change in develop-4, we now need to confirm that we intend to use v4
-    "CONFIRM_VERSION4": True,
+    "CMS_CONFIRM_VERSION4": True,
 }
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -61,6 +61,7 @@ HELPER_SETTINGS = {
     "PARLER_ENABLE_CACHING": False,
     "LANGUAGE_CODE": "en",
     # Due to a recent temporary change in develop-4, we now need to confirm that we intend to use v4
+    # https://github.com/django-cms/django-cms/commit/ff6cb9b5dced92eadef62694e989d601e9475b30
     "CMS_CONFIRM_VERSION4": True,
 }
 


### PR DESCRIPTION
- Added CMS_CONFIRM_VERSION4 in test_settings to show intend of using v4

This is a temporary step to ensure people only migrate their databases intentionally.
https://github.com/django-cms/django-cms/commit/ff6cb9b5dced92eadef62694e989d601e9475b30