### PR TITLE
feat: add custom get_actions method to PageContentAdmin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: Adds admin action to add multiple items to a collection when moderation is installed
 
 1.4.0 (2022-09-21)
 ==================

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 
-from django.apps import apps
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.sites.shortcuts import get_current_site
@@ -42,7 +41,7 @@ from .filters import (
     UnpublishedFilter,
 )
 from .forms import DuplicateForm
-from .helpers import proxy_model
+from .helpers import is_moderation_enabled, proxy_model
 
 
 try:
@@ -107,15 +106,19 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
 
     def get_actions(self, request):
         """
-        If djangocms-moderation is installed, adds admin action to allow multiple pages to be added to a moderation
-        collection
+        If djangocms-moderation is enabled, adds admin action to allow multiple pages to be added to a moderation
+        collection.
+
+        :param request: Request object
+        :returns: dict of admin actions
         """
         actions = super().get_actions(request)
-        if not apps.is_installed("djangocms_moderation"):
+        if not is_moderation_enabled():
             return actions
 
         from djangocms_moderation.admin_actions import \
             add_items_to_collection  # noqa
+
         actions["add_items_to_collection"] = (
             add_items_to_collection,
             "add_items_to_collection",

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 
+from django.apps import apps
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.sites.shortcuts import get_current_site
@@ -103,6 +104,24 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
                 .prefetch_related("content"),
             )
         )
+
+    def get_actions(self, request):
+        """
+        If djangocms-moderation is installed, adds admin action to allow multiple pages to be added to a moderation
+        collection
+        """
+        actions = super().get_actions(request)
+        if not apps.is_installed("djangocms_moderation"):
+            return actions
+
+        from djangocms_moderation.admin_actions import \
+            add_items_to_collection  # noqa
+        actions["add_items_to_collection"] = (
+            add_items_to_collection,
+            "add_items_to_collection",
+            add_items_to_collection.short_description
+        )
+        return actions
 
     def get_search_results(self, request, queryset, search_term):
         """

--- a/djangocms_pageadmin/helpers.py
+++ b/djangocms_pageadmin/helpers.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+from django.apps import apps
+
 from cms.models import PageContent
 
 from djangocms_versioning import versionables
@@ -10,3 +12,18 @@ def proxy_model(obj):
     obj_ = deepcopy(obj)
     obj_.__class__ = versionable.version_model_proxy
     return obj_
+
+
+def is_moderation_enabled():
+    """
+    Returns True if the PageContent model is enabled for moderation.
+    If it is not, or djangocms_moderation is not installed, returns False.
+
+    :returns: True or False
+    """
+    try:
+        moderation_config = apps.get_app_config("djangocms_moderation")
+    except LookupError:
+        return False
+
+    return PageContent in moderation_config.cms_extension.moderated_models

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -14,3 +14,4 @@ https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms
 https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
 https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking
+https://github.com/django-cms/djangocms-moderation/tarball/master#egg=djangocms-moderation

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,6 +25,7 @@ HELPER_SETTINGS = {
         "djangocms_versioning",
         "djangocms_version_locking",
         "djangocms_alias",
+        "djangocms_moderation",
     ],
     "LANGUAGES": (
         ("en", "English"),

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -898,9 +898,9 @@ class PageAdminCsvExportFileTestCase(CMSTestCase):
 
 class TestPageContentAdminActions(CMSTestCase):
 
-    def test_get_actions_when_moderation_is_installed(self):
+    def test_get_actions_when_moderation_is_enabled(self):
         """
-        With djangocms_moderation installed, the PageContentAdmin actions should include the action to add multiple
+        When djangocms_moderation is enabled, the PageContentAdmin actions should include the action to add multiple
         items to a collection.
         """
         pagecontent_admin = PageContentAdmin(PageContent, admin.AdminSite())
@@ -916,18 +916,18 @@ class TestPageContentAdminActions(CMSTestCase):
             )
         })
 
-    @patch("django.apps.apps.is_installed")
-    def test_get_actions_when_moderation_not_installed(self, is_installed):
+    @patch("djangocms_pageadmin.admin.is_moderation_enabled")
+    def test_get_actions_when_moderation_not_enabled(self, is_moderation_enabled):
         """
-        With djangocms_moderation not installed, the PageContentAdmin actions should include the action to add multiple
-        items to a collection. As djangocms_moderation is installed in the test environment, a mock is used to simulate
-        it not being installed.
+        When djangocms_moderation is not enabled, the PageContentAdmin actions should include the action to add multiple
+        items to a collection.
         """
-        is_installed.return_value = False
+        is_moderation_enabled.return_value = False
         pagecontent_admin = PageContentAdmin(PageContent, admin.AdminSite())
         request = self.get_request('/')
 
         actions = pagecontent_admin.get_actions(request)
+
+        is_moderation_enabled.assert_called_once()
         self.assertNotIn("add_items_to_collection", actions)
         self.assertEqual(actions, {})
-        is_installed.assert_called_once_with("djangocms_moderation")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -919,8 +919,8 @@ class TestPageContentAdminActions(CMSTestCase):
     @patch("djangocms_pageadmin.admin.is_moderation_enabled")
     def test_get_actions_when_moderation_not_enabled(self, is_moderation_enabled):
         """
-        When djangocms_moderation is not enabled, the PageContentAdmin actions should include the action to add multiple
-        items to a collection.
+        When djangocms_moderation is not enabled, the PageContentAdmin actions should not include the action to add
+        multiple items to a collection.
         """
         is_moderation_enabled.return_value = False
         pagecontent_admin = PageContentAdmin(PageContent, admin.AdminSite())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from cms.test_utils.testcases import CMSTestCase
+
+from djangocms_pageadmin.helpers import is_moderation_enabled
+
+
+class TestIsModerationEnabled(CMSTestCase):
+
+    @patch("django.apps.apps.get_app_config")
+    def test_when_config_not_found(self, mock_get_app_config):
+        """
+        As djangocms_moderation is installed in the test environment, patches get_app_config to raise a LookupError to
+        simulate djangocms_moderation not being installed
+        """
+        mock_get_app_config.side_effect = LookupError
+
+        result = is_moderation_enabled()
+
+        self.assertFalse(result)
+        mock_get_app_config.assert_called_once_with("djangocms_moderation")
+
+    @patch("django.apps.apps.get_app_config")
+    def test_config_does_not_include_page_content_model(self, mock_get_app_config):
+        """
+        As djangocms_moderation is installed in the test environment, patches get_app_config to return a mock config
+        object where we set the moderation models to an empty list, to check that the helper returns False
+        """
+        mock_config = MagicMock()
+        mock_config.cms_extension.moderated_models = []
+        mock_get_app_config.return_value = mock_config
+
+        result = is_moderation_enabled()
+
+        self.assertFalse(result)
+        mock_get_app_config.assert_called_once_with("djangocms_moderation")
+
+    def test_config_does_include_page_content_model(self):
+        """
+        The test environment has djangocms_moderation installed and enabled so this should return True
+        """
+        self.assertTrue(is_moderation_enabled())


### PR DESCRIPTION
- Adds the admin action to allow multiple items to a moderation collection
- Only adds the action when `djangocms_moderation` is installed and configured enable moderation for `PageContent`. This is to avoid adding a dependency to `djangocms_moderation`
- For testing purposes, `djangocms_moderation` is added to the test requirements and configured in the test settings