### PR TITLE
Fix editlink in pageadmin to close sideframe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+Unreleased
+=================
+* Fixed edit link in pageadmin to close sideframe
 
 1.7.0 (2024-05-16)
 ==================

--- a/djangocms_pageadmin/admin.py
+++ b/djangocms_pageadmin/admin.py
@@ -260,9 +260,10 @@ class PageContentAdmin(VersioningAdminMixin, DefaultPageContentAdmin):
             args=(version.pk,),
         )
 
+        # close sideframe as edit will always be on page and not in sideframe
         return render_to_string(
             "djangocms_pageadmin/admin/icons/edit.html",
-            {"url": url, "disabled": disabled, "get": False},
+            {"url": url, "disabled": disabled, "get": False, "keepsideframe": False},
         )
 
     def _get_duplicate_link(self, obj, request, disabled=False):


### PR DESCRIPTION
fixed edit link in page admin to close side frame.
Currently it tries to load in the side frame and goes in loop which is ideally not correct.